### PR TITLE
Simplify meta tags and update Open Graph/Twitter titles

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,32 +16,32 @@
 
     <meta
       name="description"
-      content="vancity jun software engineer full stack developer ux ui designer"
+      content="jun software engineer full stack developer"
     />
     <meta
       name="keywords"
-      content="vancity jun software engineer full stack developer ux ui designer"
+      content="jun software engineer full stack developer"
     />
     <meta name="robots" content="index,follow" />
     <meta
       property="og:title"
-      content="Software Engineer ui ux designer - Vancity Jun"
+      content="Software Engineer - Jun"
     />
     <meta
       property="og:type"
-      content="vancity jun software engineer full stack developer ux ui designer"
+      content="jun software engineer full stack developer"
     />
     <meta property="og:image" content="/img/og-image.png" />
     <meta property="og:url" content="https://www.vancityjun.com/" />
     <meta name="twitter:card" content="summary" />
     <meta
       name="twitter:title"
-      content="Software Engineer ui ux designer - Vancity Jun"
+      content="Software Engineer - Jun"
     />
     <meta name="twitter:url" content="https://www.vancityjun.com/" />
     <meta
       name="twitter:description"
-      content="vancity jun software engineer full stack developer ux ui designer"
+      content="jun software engineer full stack developer"
     />
     <meta name="twitter:image" content="/img/og-image.png" />
 


### PR DESCRIPTION
### Motivation

- Remove redundant and outdated keywords from the page metadata and simplify the Open Graph and Twitter titles for a more concise site identity.

### Description

- Updated the `description` and `keywords` meta tags to `"jun software engineer full stack developer"` from the previous longer string. 
- Replaced `og:title` and `twitter:title` values from `"Software Engineer ui ux designer - Vancity Jun"` to `"Software Engineer - Jun"` to streamline social previews. 
- Normalized `og:type` and `twitter:description` content to the simplified descriptor and removed occurrences of `vancity` and `ui ux designer` from meta values.

### Testing

- Ran a local site build with `npm run build` which completed successfully. 
- Validated the edited HTML with `npx htmlhint index.html` and received no linting errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c922096588326bc5f3321617f0f3a)